### PR TITLE
Domain user support via kerberos/spnego

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,14 +62,13 @@ Once built, you can run remote commands like this:
 
 ### kerberos authentication
 
-Ensure you have a ticket granting ticket before running winrm (use kinit/klist)
-Also make sure remote.domain.com can be resolved forward and reverse
+Ensure you have a ticket granting ticket before running winrm (use kinit/klist). Also make sure remote.domain.com can be resolved forward and reverse
 
 ```sh
 ./winrm -kerberos -hostname remote.domain.com "ipconfig /all"
 ```
-These options can be set as environment variables before running winrm :
-KRB5_CONFIG points the kerberos config file. Default value is "/etc/krb5.conf"
+These options can be set as environment variables before running winrm :  
+KRB5_CONFIG points the kerberos config file. Default value is "/etc/krb5.conf"  
 KRB5CCNAME points the credential cache file. Default value is "/tmp/krb5cc_${UID}"
 
 ## Docker

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 This is a Go command-line executable to execute remote commands on Windows machines through
 the use of WinRM/WinRS.
 
-_Note_: this tool doesn't support domain users (it doesn't support GSSAPI nor Kerberos). It's primary target is to execute remote commands on EC2 windows machines.
+This tool support domain users via kerberos switch. For this to work, you will need a valid TGT (use kinit), a valid krb5.conf and your target must have a resolvable reverse entry.
 
 ## Contact
 
@@ -13,8 +13,8 @@ _Note_: this tool doesn't support domain users (it doesn't support GSSAPI nor Ke
 ## Getting Started
 WinRM is available on Windows Server 2008 and up. This project natively supports basic authentication for local accounts, see the steps in the next section on how to prepare the remote Windows machine for this scenario. The authentication model is pluggable, see below for an example on using Negotiate/NTLM authentication (e.g. for connecting to vanilla Azure VMs).
 
-### Preparing the remote Windows machine for Basic authentication
-This project supports only basic authentication for local accounts (domain users are not supported). The remote windows system must be prepared for winrm:
+### Preparing the remote Windows machine for Basic authentication (Not needed for Kerberos)
+If you can not use kerberos, use basic authentication for local accounts. The remote windows system must be prepared for winrm:
 
 _For a PowerShell script to do what is described below in one go, check [Richard Downer's blog](http://www.frontiertown.co.uk/2011/12/overthere-control-windows-from-java/)_
 
@@ -59,6 +59,18 @@ Once built, you can run remote commands like this:
 ```sh
 ./winrm -hostname remote.domain.com -username "Administrator" -password "secret" "ipconfig /all"
 ```
+
+### kerberos authentication
+
+Ensure you have a ticket granting ticket before running winrm (use kinit/klist)
+Also make sure remote.domain.com can be resolved forward and reverse
+
+```sh
+./winrm -kerberos -hostname remote.domain.com "ipconfig /all"
+```
+These options can be set as environment variables before running winrm :
+KRB5_CONFIG points the kerberos config file. Default value is "/etc/krb5.conf"
+KRB5CCNAME points the credential cache file. Default value is "/tmp/krb5cc_${UID}"
 
 ## Docker
 

--- a/winrm.go
+++ b/winrm.go
@@ -37,6 +37,7 @@ func main() {
 		user     string
 		pass     string
 		ntlm     bool
+		kerberos bool
 		cmd      string
 		port     int
 		encoded  bool
@@ -52,6 +53,7 @@ func main() {
 	flag.StringVar(&user, "username", "vagrant", "winrm admin username")
 	flag.StringVar(&pass, "password", "vagrant", "winrm admin password")
 	flag.BoolVar(&ntlm, "ntlm", false, "use use ntlm auth")
+	flag.BoolVar(&kerberos, "kerberos", false, "use kerberos auth. You need a TGT for this (obtained via kinit)")
 	flag.BoolVar(&encoded, "encoded", false, "use base64 encoded password")
 	flag.IntVar(&port, "port", 5985, "winrm port")
 	flag.BoolVar(&https, "https", false, "use https")
@@ -117,6 +119,10 @@ func main() {
 
 		if ntlm {
 			params.TransportDecorator = func() winrm.Transporter { return &winrm.ClientNTLM{} }
+		}
+
+		if kerberos {
+			params.TransportDecorator = func() winrm.Transporter { return &winrm.ClientKerberos{} }
 		}
 
 		client, err := winrm.NewClientWithParameters(endpoint, user, pass, params)

--- a/winrm.go
+++ b/winrm.go
@@ -33,20 +33,21 @@ import (
 
 func main() {
 	var (
-		hostname string
-		user     string
-		pass     string
-		ntlm     bool
-		kerberos bool
-		cmd      string
-		port     int
-		encoded  bool
-		https    bool
-		insecure bool
-		cacert   string
-		gencert  bool
-		certsize string
-		timeout  string
+		hostname  string
+		user      string
+		pass      string
+		ntlm      bool
+		kerberos  bool
+		nonscheck bool
+		cmd       string
+		port      int
+		encoded   bool
+		https     bool
+		insecure  bool
+		cacert    string
+		gencert   bool
+		certsize  string
+		timeout   string
 	)
 
 	flag.StringVar(&hostname, "hostname", "localhost", "winrm host")
@@ -54,6 +55,7 @@ func main() {
 	flag.StringVar(&pass, "password", "vagrant", "winrm admin password")
 	flag.BoolVar(&ntlm, "ntlm", false, "use use ntlm auth")
 	flag.BoolVar(&kerberos, "kerberos", false, "use kerberos auth. You need a TGT for this (obtained via kinit)")
+	flag.BoolVar(&nonscheck, "no-dns-check", false, "using kerberos auth, do not canonicalize hostname. Useful when reverse not available")
 	flag.BoolVar(&encoded, "encoded", false, "use base64 encoded password")
 	flag.IntVar(&port, "port", 5985, "winrm port")
 	flag.BoolVar(&https, "https", false, "use https")
@@ -122,7 +124,11 @@ func main() {
 		}
 
 		if kerberos {
-			params.TransportDecorator = func() winrm.Transporter { return &winrm.ClientKerberos{} }
+			if nonscheck {
+				params.TransportDecorator = func() winrm.Transporter { return &winrm.ClientKerberosWithNoCanonicalize{} }
+			} else {
+				params.TransportDecorator = func() winrm.Transporter { return &winrm.ClientKerberos{} }
+			}
 		}
 
 		client, err := winrm.NewClientWithParameters(endpoint, user, pass, params)


### PR DESCRIPTION
Add a "-kerberos" switch for domain user authentication via kerberos.
Successfully tested on linux and freebsd host, running commands on hosts in a child domain.
Does not support TGT creation (you have to get it with kinit first)